### PR TITLE
Add set_modbus_register_bit service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ add_service_files(
     get_alarms.srv
     ack_alarm.srv
     set_modbus_register.srv
+    set_modbus_register_bit.srv
     get_modbus_register.srv
     GetBool.srv
     set_CartesianEuler_pose.srv

--- a/srv/set_modbus_register_bit.srv
+++ b/srv/set_modbus_register_bit.srv
@@ -1,0 +1,5 @@
+int16 address
+int16 bit
+bool value
+---
+bool ret


### PR DESCRIPTION
New service to set values for specific bits in a Modbus register.

Used by robotnik_modbus_io main branch (agvr_devel) from commit _5b329a_.