### PR TITLE
Feat/unify zoom control units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ add_message_files(DIRECTORY msg
     RecordStatus.msg
     SimpleSystemStatus.msg
     Interval.msg
+    CameraParameters.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/msg/CameraParameters.msg
+++ b/msg/CameraParameters.msg
@@ -1,3 +1,4 @@
 int8 min_zoom_step 
 int8 zoom_lower_limit
 int8 zoom_upperlimit 
+int32[] zoom_augments

--- a/msg/CameraParameters.msg
+++ b/msg/CameraParameters.msg
@@ -1,0 +1,3 @@
+int8 min_zoom_step 
+int8 zoom_lower_limit
+int8 zoom_upperlimit 

--- a/package.xml
+++ b/package.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0"?>
 <package>
   <name>robotnik_msgs</name>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <description>The robotnik_msgs package. Common messages and services used by some Robotnik's packages.</description>
 
   <maintainer email="asoriano@robotnik.es">Angel Soriano</maintainer>
-  <maintainer email="avillena@robotnik.es">Álvaro Villena</maintainer>
   <maintainer email="aarnal@robotnik.es">Alejandro Arnal</maintainer>
   <maintainer email="mbosch@robotnik.es">Marc Bosch</maintainer>
   <maintainer email="rnavarro@robotnik.es">Román Navarro</maintainer>
   <maintainer email="jmnavarrete@robotnik.es">Juan Manuel Navarrete</maintainer>
   <maintainer email="rvasquez@robotnik.es">Robert Vásquez</maintainer>
-  <maintainer email="jmartinez@robotnik.es">Javier Martinez</maintainer>
+  <maintainer email="rcarta@robotnik.es">Roberto Carta</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
This pull request includes updates to the `CMakeLists.txt` and the addition of a new message file to the `msg` directory. The most important changes are the inclusion of the `CameraParameters.msg` file in the build process and the definition of new parameters within this message file.

Updates to build configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR76): Added `CameraParameters.msg` to the list of message files to be processed.

New message definitions:

* [`msg/CameraParameters.msg`](diffhunk://#diff-7c486149424e6cc2fcb8fc3d50cff31bdd2737661f8cda80f8e6e210ecd07d4bR1-R4): Added definitions for `min_zoom_step`, `zoom_lower_limit`, `zoom_upperlimit`, and `zoom_augments` parameters.