### PR TITLE
feat: noetic/add new field battery docking

### DIFF
--- a/msg/BatteryDockingStatus.msg
+++ b/msg/BatteryDockingStatus.msg
@@ -12,3 +12,4 @@ string operation_mode
 	
 bool contact_relay_status	# shows if there's contact with the charger
 bool charger_relay_status   # shows if the relay for the charge is active or not
+bool charger_enabled_status # shows if the charger is enabled or not. This is the one that should be used to know if the robot is able to charge phisically or not

--- a/package.xml
+++ b/package.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
 <package>
   <name>robotnik_msgs</name>
-  <version>2.5.0</version>
+  <version>2.6.0</version>
   <description>The robotnik_msgs package. Common messages and services used by some Robotnik's packages.</description>
 
   <maintainer email="asoriano@robotnik.es">Angel Soriano</maintainer>
-  <maintainer email="aarnal@robotnik.es">Alejandro Arnal</maintainer>
   <maintainer email="mbosch@robotnik.es">Marc Bosch</maintainer>
   <maintainer email="rnavarro@robotnik.es">Román Navarro</maintainer>
   <maintainer email="jmnavarrete@robotnik.es">Juan Manuel Navarrete</maintainer>
   <maintainer email="rvasquez@robotnik.es">Robert Vásquez</maintainer>
-  <maintainer email="rcarta@robotnik.es">Roberto Carta</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
This pull request introduces a new status field to the battery docking status message and updates the package version to reflect this addition.

Message definition update:

* Added a new boolean field `charger_enabled_status` to the `BatteryDockingStatus.msg` message. This field indicates whether the charger is enabled and should be used to determine if the robot is physically able to charge.

Package metadata update:

* Updated the package version from `2.5.0` to `2.6.0` in `package.xml` to reflect the new feature addition.